### PR TITLE
switch opencv dependency to headless

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 earthpy
 numpy
-opencv-python
+opencv-python-headless
 pyjson5
 pyproj
 rasterio


### PR DESCRIPTION
The regular openCV package has dependencies on a graphical desktop environment, which are not needed for this program. On some platforms (docker, servers, etc) this package will not work without also installing a complete desktop environment. The headless package doesn't have these restrictions.